### PR TITLE
Initial adjacency matrix transformations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,6 @@ repos:
       args: [--fix]
     # Run the formatter.
     - id: ruff-format
-- repo: https://github.com/RobertCraigie/pyright-python
-  rev: v1.1.341
-  hooks:
-    - id: pyright
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.3.0
   hooks:

--- a/mlx_graphs/utils/transformations.py
+++ b/mlx_graphs/utils/transformations.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import mlx.core as mx
 import numpy as np
 
@@ -79,3 +80,51 @@ def to_sparse_adjacency_matrix(adjacency_matrix: mx.array) -> tuple[mx.array, mx
     edge_index = to_edge_index(adjacency_matrix)
     edge_features = adjacency_matrix[edge_index[0], edge_index[1]]
     return edge_index, edge_features
+
+
+def to_adjacency_matrix(
+    edge_index: mx.array, num_nodes: int, edge_features: Optional[mx.array] = None
+) -> mx.array:
+    """
+    Converts an edge index representation to an adjacency matrix.
+
+    Args:
+        edge_index (mlx.core.array): a [2, num_edges] array representing the source and target nodes of each edge
+        num_nodes (int): the number of nodes in the graph
+        edge_features (mlx.core.array, optional): edge features corresponding to the edges in edge_index. Defaults to None.
+
+    Returns:
+        mlx.core.array: the resulting adjacency matrix
+    """
+    if mx.max(edge_index) > num_nodes - 1:
+        raise ValueError(
+            "num_nodes must be >= than the number of nodes in the edge_index ",
+            f"(got num_nodes={num_nodes} and {mx.max(edge_index) + 1} nodes in index",
+        )
+    if edge_index.ndim != 2:
+        raise ValueError(
+            "edge_index must be 2-dimensional with shape [2, num_edges]",
+            f"(got {edge_index.ndim} dimensions)",
+        )
+    if edge_index.shape[0] != 2:
+        raise ValueError(
+            "edge_index must be 2-dimensional with shape [2, num_edges]",
+            f"(got {edge_index.shape} shape)",
+        )
+
+    if edge_features is not None:
+        if edge_features.ndim != 1:
+            raise ValueError(
+                f"edge_features must be 1-dimensional (got {edge_features.ndim} dimensions)"
+            )
+        if edge_index.shape[1] != edge_features.shape[0]:
+            raise ValueError(
+                "edge_features must be 1 per edge ",
+                f"(got {edge_index.shape[1]} edges and {edge_features.shape[0]} features)",
+            )
+    adjacency_matrix = mx.zeros((num_nodes, num_nodes), dtype=edge_index.dtype)
+    if edge_features is None:
+        adjacency_matrix[edge_index[0], edge_index[1]] = 1
+    else:
+        adjacency_matrix[edge_index[0], edge_index[1]] = edge_features
+    return adjacency_matrix

--- a/mlx_graphs/utils/transformations.py
+++ b/mlx_graphs/utils/transformations.py
@@ -1,0 +1,81 @@
+import mlx.core as mx
+import numpy as np
+
+
+def check_adjacency_matrix(func):
+    """Decorator function to check the validity of an adjacency matrix."""
+
+    def wrapper(adjacency_matrix, *args, **kwargs):
+        if adjacency_matrix.ndim != 2:
+            raise ValueError(
+                f"Adjacency matrix must be two-dimensional (got {adjacency_matrix.ndim} dimensions)"
+            )
+        if not mx.equal(*adjacency_matrix.shape):
+            raise ValueError(
+                f"Adjacency matrix must be a square matrix (got {adjacency_matrix.shape} shape)"
+            )
+        return func(adjacency_matrix, *args, **kwargs)
+
+    return wrapper
+
+
+@check_adjacency_matrix
+def to_edge_index(adjacency_matrix: mx.array) -> mx.array:
+    """
+    Converts an adjacency matrix to an edge index representation.
+
+    Args:
+        adjacency_matrix (mlx.core.array): the input adjacency matrix
+
+    Returns:
+        mlx.core.array: a [2, num_edges] array representing the source and target nodes of each edge
+
+    .. code-block:: python
+        matrix = mx.array(
+            [
+                [0, 1, 2],
+                [3, 0, 0],
+                [5, 1, 2],
+            ]
+        )
+        edge_index = to_edge_index(matrix)
+        # mx.array([[0, 0, 1, 2, 2, 2], [1, 2, 0, 0, 1, 2]])
+    """
+    input_dtype = adjacency_matrix.dtype
+    edge_index = mx.stack(
+        [mx.array(x, dtype=input_dtype) for x in np.nonzero(adjacency_matrix)]
+    )
+    return edge_index
+
+
+@check_adjacency_matrix
+def to_sparse_adjacency_matrix(adjacency_matrix: mx.array) -> tuple[mx.array, mx.array]:
+    """
+    Converts a dense adjacency matrix to a sparse one, represented as an tuple of and
+    edge index and edge features.
+
+    Args:
+        adjacency_matrix (mlx.core.array): the input adjacency matrix
+
+    Returns:
+        tuple[mlx.core.array, mlx.core.array]: A tuple representing the edge index and edge features
+
+    .. code-block:: python
+        matrix = mx.array(
+            [
+                [0, 1, 2],
+                [3, 0, 0],
+                [5, 1, 2],
+            ]
+        )
+        edge_index, edge_features = to_sparse_adjacency_matrix(matrix)
+
+        edge_index
+        # mx.array([[0, 0, 1, 2, 2, 2], [1, 2, 0, 0, 1, 2]])
+
+        edge_features
+        # mx.array([1, 2, 3, 5, 1, 2])
+    """
+    edge_index = to_edge_index(adjacency_matrix)
+    edge_features = adjacency_matrix[edge_index[0], edge_index[1]]
+    return edge_index, edge_features

--- a/mlx_graphs/utils/transformations.py
+++ b/mlx_graphs/utils/transformations.py
@@ -21,12 +21,13 @@ def check_adjacency_matrix(func):
 
 
 @check_adjacency_matrix
-def to_edge_index(adjacency_matrix: mx.array) -> mx.array:
+def to_edge_index(adjacency_matrix: mx.array, dtype: mx.Dtype = mx.uint32) -> mx.array:
     """
     Converts an adjacency matrix to an edge index representation.
 
     Args:
         adjacency_matrix (mlx.core.array): the input adjacency matrix
+        dtype (mlx.core.Dtype): type of the output edge_index. Default to uint32.
 
     Returns:
         mlx.core.array: a [2, num_edges] array representing the source and target nodes of each edge
@@ -42,21 +43,22 @@ def to_edge_index(adjacency_matrix: mx.array) -> mx.array:
         edge_index = to_edge_index(matrix)
         # mx.array([[0, 0, 1, 2, 2, 2], [1, 2, 0, 0, 1, 2]])
     """
-    input_dtype = adjacency_matrix.dtype
     edge_index = mx.stack(
-        [mx.array(x, dtype=input_dtype) for x in np.nonzero(adjacency_matrix)]
+        [mx.array(x, dtype=dtype) for x in np.nonzero(adjacency_matrix)]
     )
     return edge_index
 
 
 @check_adjacency_matrix
-def to_sparse_adjacency_matrix(adjacency_matrix: mx.array) -> tuple[mx.array, mx.array]:
+def to_sparse_adjacency_matrix(
+    adjacency_matrix: mx.array, dtype: mx.Dtype = mx.uint32
+) -> tuple[mx.array, mx.array]:
     """
-    Converts a dense adjacency matrix to a sparse one, represented as an tuple of and
-    edge index and edge features.
+    Converts an adjacency matrix to a sparse representation as a tuple of edge index and edge features.
 
     Args:
         adjacency_matrix (mlx.core.array): the input adjacency matrix
+        dtype (mlx.core.Dtype): type of the output edge_index. Default to uint32.
 
     Returns:
         tuple[mlx.core.array, mlx.core.array]: A tuple representing the edge index and edge features

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -3,6 +3,7 @@ from mlx_graphs.utils.transformations import (
     to_edge_index,
     to_sparse_adjacency_matrix,
     check_adjacency_matrix,
+    to_adjacency_matrix,
 )
 import pytest
 
@@ -47,3 +48,53 @@ def test_to_sparse_adjacency_matrix():
     assert mx.array_equal(edge_index, expected_index)
     expected_features = mx.array([1, 2, 3, 5, 1, 2])
     assert mx.array_equal(edge_features, expected_features)
+
+
+def test_to_adjacency_matrix():
+    edge_index = mx.array([[0, 0, 1, 2, 2, 2], [1, 2, 0, 0, 1, 2]])
+    edge_features = mx.array([1, 2, 3, 5, 1, 2])
+
+    # 3 nodes
+    num_nodes = 3
+    expected_binary_matrix = mx.array([[0, 1, 1], [1, 0, 0], [1, 1, 1]])
+    adj_matrix = to_adjacency_matrix(edge_index, num_nodes)
+    assert mx.array_equal(expected_binary_matrix, adj_matrix)
+    expected_matrix = mx.array([[0, 1, 2], [3, 0, 0], [5, 1, 2]])
+    weighted_adj_matrix = to_adjacency_matrix(edge_index, num_nodes, edge_features)
+    assert mx.array_equal(expected_matrix, weighted_adj_matrix)
+
+    # 4 nodes (extra padding)
+    num_nodes = 4
+    expected_binary_matrix = mx.array(
+        [[0, 1, 1, 0], [1, 0, 0, 0], [1, 1, 1, 0], [0, 0, 0, 0]]
+    )
+    adj_matrix = to_adjacency_matrix(edge_index, num_nodes)
+    assert mx.array_equal(expected_binary_matrix, adj_matrix)
+    expected_matrix = mx.array([[0, 1, 2, 0], [3, 0, 0, 0], [5, 1, 2, 0], [0, 0, 0, 0]])
+    weighted_adj_matrix = to_adjacency_matrix(edge_index, num_nodes, edge_features)
+    assert mx.array_equal(expected_matrix, weighted_adj_matrix)
+
+    # 2 nodes (expect error as there are 3 in index)
+    with pytest.raises(ValueError):
+        to_adjacency_matrix(edge_index, num_nodes=2)
+    # non 2D edge_index
+    with pytest.raises(ValueError):
+        edge_index = mx.array([[[0, 0, 1, 2, 2, 2], [1, 2, 0, 0, 1, 2]]])
+        to_adjacency_matrix(edge_index, 3)
+
+    # column edge_index
+    with pytest.raises(ValueError):
+        edge_index = mx.array([[0, 1], [1, 2], [0, 2]])
+        to_adjacency_matrix(edge_index, 3)
+
+    # more features than edges
+    with pytest.raises(ValueError):
+        edge_index = mx.array([[0, 0, 1, 2, 2, 2], [1, 2, 0, 0, 1, 2]])
+        edge_features = mx.array([1, 2, 3, 5, 1, 2, 5])
+        to_adjacency_matrix(edge_index, 3, edge_features)
+
+    # less features than edges
+    with pytest.raises(ValueError):
+        edge_index = mx.array([[0, 0, 1, 2, 2, 2], [1, 2, 0, 0, 1, 2]])
+        edge_features = mx.array([1, 2, 3, 5, 1])
+        to_adjacency_matrix(edge_index, 3, edge_features)

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -1,0 +1,49 @@
+import mlx.core as mx
+from mlx_graphs.utils.transformations import (
+    to_edge_index,
+    to_sparse_adjacency_matrix,
+    check_adjacency_matrix,
+)
+import pytest
+
+
+@pytest.mark.parametrize(
+    "x, expected_exception",
+    [
+        (mx.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]]), None),  # Valid matrix
+        (mx.array([[0, 1, 0], [1, 0, 1]]), ValueError),  # Non-square matrix
+        (mx.array([0, 1, 0, 1, 0, 1]), ValueError),  # 1D matrix
+        (mx.array([[[0]]]), ValueError),  # 3D matrix
+    ],
+)
+def test_check_adjacency_matrix(x, expected_exception):
+    @check_adjacency_matrix
+    def foo(adjacency_matrix):
+        return True
+
+    if expected_exception:
+        with pytest.raises(expected_exception):
+            foo(adjacency_matrix=x)
+    else:
+        assert foo(adjacency_matrix=x) is True
+
+
+def test_to_edge_index():
+    matrix = mx.array([[0, 1, 2], [3, 0, 0], [5, 1, 2]])
+    edge_index = to_edge_index(matrix)
+    assert edge_index.dtype == matrix.dtype
+
+    expected_output = mx.array([[0, 0, 1, 2, 2, 2], [1, 2, 0, 0, 1, 2]])
+    assert mx.array_equal(edge_index, expected_output)
+
+
+def test_to_sparse_adjacency_matrix():
+    matrix = mx.array([[0, 1, 2], [3, 0, 0], [5, 1, 2]])
+    edge_index, edge_features = to_sparse_adjacency_matrix(matrix)
+    assert edge_index.dtype == matrix.dtype
+    assert edge_features.dtype == matrix.dtype
+
+    expected_index = mx.array([[0, 0, 1, 2, 2, 2], [1, 2, 0, 0, 1, 2]])
+    assert mx.array_equal(edge_index, expected_index)
+    expected_features = mx.array([1, 2, 3, 5, 1, 2])
+    assert mx.array_equal(edge_features, expected_features)

--- a/tests/utils/test_transformations.py
+++ b/tests/utils/test_transformations.py
@@ -26,28 +26,49 @@ def test_check_adjacency_matrix(x, expected_exception):
         with pytest.raises(expected_exception):
             foo(adjacency_matrix=x)
     else:
-        assert foo(adjacency_matrix=x) is True
+        assert (
+            foo(adjacency_matrix=x) is True
+        ), "Input with valid adjacency matrix failed"
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        (mx.uint8),
+        (mx.uint16),
+        (mx.uint32),
+        (mx.uint64),
+        (mx.int8),
+        (mx.int16),
+        (mx.int32),
+        (mx.int64),
+    ],
+)
+def test_to_edge_index_dtype(dtype):
+    matrix = mx.array([[0, 1], [3, 0]])
+    edge_index = to_edge_index(matrix, dtype=dtype)
+    assert edge_index.dtype == dtype, "dtype of returned array incorrect"
 
 
 def test_to_edge_index():
     matrix = mx.array([[0, 1, 2], [3, 0, 0], [5, 1, 2]])
     edge_index = to_edge_index(matrix)
-    assert edge_index.dtype == matrix.dtype
+    assert edge_index.dtype == mx.uint32, "Default dtype of returned array != uint32"
 
     expected_output = mx.array([[0, 0, 1, 2, 2, 2], [1, 2, 0, 0, 1, 2]])
-    assert mx.array_equal(edge_index, expected_output)
+    assert mx.array_equal(
+        edge_index, expected_output
+    ), "Incorrectly computed edge index"
 
 
 def test_to_sparse_adjacency_matrix():
     matrix = mx.array([[0, 1, 2], [3, 0, 0], [5, 1, 2]])
     edge_index, edge_features = to_sparse_adjacency_matrix(matrix)
-    assert edge_index.dtype == matrix.dtype
-    assert edge_features.dtype == matrix.dtype
 
     expected_index = mx.array([[0, 0, 1, 2, 2, 2], [1, 2, 0, 0, 1, 2]])
-    assert mx.array_equal(edge_index, expected_index)
+    assert mx.array_equal(edge_index, expected_index), "Incorrect computed edge index"
     expected_features = mx.array([1, 2, 3, 5, 1, 2])
-    assert mx.array_equal(edge_features, expected_features)
+    assert mx.array_equal(edge_features, expected_features), "Incorrect edge features"
 
 
 def test_to_adjacency_matrix():
@@ -58,10 +79,14 @@ def test_to_adjacency_matrix():
     num_nodes = 3
     expected_binary_matrix = mx.array([[0, 1, 1], [1, 0, 0], [1, 1, 1]])
     adj_matrix = to_adjacency_matrix(edge_index, num_nodes)
-    assert mx.array_equal(expected_binary_matrix, adj_matrix)
+    assert mx.array_equal(
+        expected_binary_matrix, adj_matrix
+    ), "Incorrect conversion to adjacency matrix"
     expected_matrix = mx.array([[0, 1, 2], [3, 0, 0], [5, 1, 2]])
     weighted_adj_matrix = to_adjacency_matrix(edge_index, num_nodes, edge_features)
-    assert mx.array_equal(expected_matrix, weighted_adj_matrix)
+    assert mx.array_equal(
+        expected_matrix, weighted_adj_matrix
+    ), "Incorrect conversion to weighted adjacency matrix"
 
     # 4 nodes (extra padding)
     num_nodes = 4
@@ -69,32 +94,33 @@ def test_to_adjacency_matrix():
         [[0, 1, 1, 0], [1, 0, 0, 0], [1, 1, 1, 0], [0, 0, 0, 0]]
     )
     adj_matrix = to_adjacency_matrix(edge_index, num_nodes)
-    assert mx.array_equal(expected_binary_matrix, adj_matrix)
+    assert mx.array_equal(
+        expected_binary_matrix, adj_matrix
+    ), "Incorrect conversion to adjacency matrix"
     expected_matrix = mx.array([[0, 1, 2, 0], [3, 0, 0, 0], [5, 1, 2, 0], [0, 0, 0, 0]])
     weighted_adj_matrix = to_adjacency_matrix(edge_index, num_nodes, edge_features)
-    assert mx.array_equal(expected_matrix, weighted_adj_matrix)
+    assert mx.array_equal(
+        expected_matrix, weighted_adj_matrix
+    ), "Incorrect conversion to weighted adjacency matrix"
 
     # 2 nodes (expect error as there are 3 in index)
     with pytest.raises(ValueError):
         to_adjacency_matrix(edge_index, num_nodes=2)
+
     # non 2D edge_index
     with pytest.raises(ValueError):
-        edge_index = mx.array([[[0, 0, 1, 2, 2, 2], [1, 2, 0, 0, 1, 2]]])
-        to_adjacency_matrix(edge_index, 3)
+        to_adjacency_matrix(edge_index.reshape([1, 2, 6]), 3)
 
     # column edge_index
     with pytest.raises(ValueError):
-        edge_index = mx.array([[0, 1], [1, 2], [0, 2]])
-        to_adjacency_matrix(edge_index, 3)
+        to_adjacency_matrix(edge_index.transpose(), 3)
 
     # more features than edges
     with pytest.raises(ValueError):
-        edge_index = mx.array([[0, 0, 1, 2, 2, 2], [1, 2, 0, 0, 1, 2]])
         edge_features = mx.array([1, 2, 3, 5, 1, 2, 5])
         to_adjacency_matrix(edge_index, 3, edge_features)
 
     # less features than edges
     with pytest.raises(ValueError):
-        edge_index = mx.array([[0, 0, 1, 2, 2, 2], [1, 2, 0, 0, 1, 2]])
         edge_features = mx.array([1, 2, 3, 5, 1])
         to_adjacency_matrix(edge_index, 3, edge_features)


### PR DESCRIPTION
This PR implements:
- `to_edge_index`: to get the edge_index starting from a dense adjacency matrix
- `to_sparse_adjacency_matrix`: to go from a dense adjacency matrix to a sparse representation (edge_index, edge_features)
- `to_adjacency_matrix`: inverse of the above

Notes: 
- using `numpy` as `mlx` doesn't directly implement `nonzero`
- I'm also temporarily removing pyright from the committed pre-commit as it needs to be configured with the local venv to work. 