### PR TITLE
Initial CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,36 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: PR
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pytest pytest-cov pre-commit
+        pre-commit install
+    - name: Run lint
+      run: |
+        pre-commit run --all-files
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-latest-xlarge
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,9 +8,9 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  linting:
 
-    runs-on: macos-latest-xlarge
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -25,12 +25,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install pytest pytest-cov pre-commit
+        pip install pre-commit
         pre-commit install
     - name: Run lint
       run: |
         pre-commit run --all-files
-    - name: Test with pytest
-      run: |
-        pytest

--- a/.github/workflows/pull_request_linting.yml
+++ b/.github/workflows/pull_request_linting.yml
@@ -1,5 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+# This workflow runs the linting and formatting specified in the pre-commit hooks
 
 name: PR
 
@@ -14,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Setting up initial CI workflow to test linting and formatting.

> Note: having tests (via `pytest`) in CI is currently not possible because they need to run on Apple silicon.