### PR TITLE
publish doc on push to main

### DIFF
--- a/.github/workflows/push_update_docs.yml
+++ b/.github/workflows/push_update_docs.yml
@@ -2,14 +2,17 @@ name: build-sphinx-docs
 
 on:
   push:
-    branches: ["gh_pages"]
+    branches:
+      - main
 
-  workflow_dispatch:
+    workflow_dispatch:
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repo content
@@ -24,7 +27,8 @@ jobs:
         run: |
           cd docs/
           make html
-          # sphinx-build -b html source build
-      - name: Run ghp-import
-        run: |
-          ghp-import -n -p -f docs/build/html
+      - name: Deploy to external repos
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build/html


### PR DESCRIPTION
## Proposed changes

This will publish the new documentation and push it to the `gh-pages` branch on every push to main.

@TristanBilot please make sure to update `Settings -> Pages -> Build and deployment` to `Deploy from a branch` with the branch selected to be `gh-pages` from `root`

<img width="804" alt="Screenshot 2024-01-31 at 11 16 34" src="https://github.com/TristanBilot/mlx-graphs/assets/19568231/9f68b80c-bc68-4838-8e73-276f4212c263">

I have it working on my fork [here](https://francescofarina.github.io/mlx-graphs/)