### PR TITLE
Pypi package release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release Python Package
+
+on:
+  release:
+    types: [published]
+
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/mlx-graphs
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ pip install -e '.[dev]'
 pip install -e '.[benchmarks]'
 pip install -e '.[docs]'
 ```
+For dev purposes you may want to install the current version of `mlx` via `pip install mlx @ git+https://github.com/ml-explore/mlx.git`
 
 #### Testing
 We encourage to write tests for all components. CI is currently not in place as runners with Apple Silicon are required.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -35,3 +35,6 @@ To install any extra dependencies for testing, development and building document
 	pip install -e '.[dev]'
 	pip install -e '.[benchmarks]'
 	pip install -e '.[docs]'
+
+
+For dev purposes you may want to install the current version of `mlx` via `pip install mlx @ git+https://github.com/ml-explore/mlx.git`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "mlx @ git+https://github.com/ml-explore/mlx.git",
   "pre-commit==3.6.0",
 ]
 test = [


### PR DESCRIPTION
## Proposed changes

This PR introduces a workflow to publish the package on Pypi when we create a new release (I already setup the auth on pypi).
For package publishing to work we can't have git dependencies among the dependencies of the package, so I removed the `mlx` git dependency from the dev dependencies and updated the install instructions for dev.

Addressing issue https://github.com/TristanBilot/mlx-graphs/issues/33
