### PR TITLE
Build docs on release

### DIFF
--- a/.github/workflows/push_update_docs.yml
+++ b/.github/workflows/push_update_docs.yml
@@ -1,11 +1,8 @@
 name: build-sphinx-docs
 
 on:
-  push:
-    branches:
-      - main
-
-    workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
## Proposed changes

Documentation is currently built and published every time we push to main.
Since we're now releasing the package is probably best to build and publish the new docs only on new releases
